### PR TITLE
Fix IPv6 next header checking, and load ICMPv6 handler.

### DIFF
--- a/pypacker/layer3/ip6.py
+++ b/pypacker/layer3/ip6.py
@@ -253,12 +253,12 @@ ext_hdrs_cls = {
 		}
 
 # load handler
-from pypacker.layer3 import esp, icmp, igmp, ipx, pim
+from pypacker.layer3 import esp, icmp6, igmp, ipx, pim
 from pypacker.layer4 import tcp, udp, sctp
 
 pypacker.Packet.load_handler(IP6,
 				{
-				IP_PROTO_ICMP : icmp.ICMP,
+				IP_PROTO_ICMP6 : icmp6.ICMP6,
 				IP_PROTO_IGMP : igmp.IGMP,
 				IP_PROTO_TCP : tcp.TCP,
 				IP_PROTO_UDP : udp.UDP,


### PR DESCRIPTION
IPv6 next header is always zero, so check buf[6] (ip6.nxt field).
In the IPv6 handler, replaced ICMP with ICMPv6.
