### PR TITLE
layer567/dns.py: add domain name encoder and decoder

### DIFF
--- a/pypacker/layer567/dns.py
+++ b/pypacker/layer567/dns.py
@@ -88,6 +88,35 @@ DNS_HESIOD		= 4
 DNS_ANY			= 255
 
 
+def name_decode(name):
+	"""DNS domain name decoder
+
+	ex)
+		Input : b'\x03www\x07example\x03com'
+		Output: 'www.example.com.'
+	"""
+	name_decoded = []
+	off = 1
+	while off < len(name):
+		name_decoded.append(name[off:off+name[off-1]].decode())
+		off = off + name[off-1] + 1
+	return ".".join(name_decoded) + "."
+
+
+def name_encode(name):
+	"""DNS domain name encoder
+
+	ex)
+		Input : 'www.example.com'
+		Output: b'\x03www\x07example\x03com'
+	"""
+	name_encoded = b""
+	labels = [n.encode() for n in name.split('.') if not n==""]
+	for label in labels:
+		name_encoded = name_encoded + chr(len(label)).encode() + label
+	return name_encoded
+
+
 class DNSTriggerList(triggerlist.TriggerList):
 	def _handle_mod(self, val):
 		# update amounts


### PR DESCRIPTION
Add function to assemble DNS name.
This patch will work as below.

```
>>> from pypacker.layer567 import dns
>>> dns.name_encode("www.example.com")
b'\x03www\x07example\x03com'
>>> dns.name_decode(b"\x03www\x07example\x03com")
'www.example.com.'
>>>
>>> dns_h = dns.DNS(queries=dns.DNS.Query(name=dns.name_encode("www.example.com")))
>>> dns_h
DNS(id=4660, flags=288, questions_amount=1, answers_amount=0, authrr_amount=0, addrr_amount=0, queries=[Query(name=[b'\x03www\x07example\x03com'], postfix=0, type=1, cls=1, bytes=b'')], answers=[], auths=[], addrecords=[], bytes=b'')
>>> dns_h.queries[0].name[0]
b'\x03www\x07example\x03com'
>>> dns.name_decode(dns_h.queries[0].name[0])
'www.example.com.'
```