### PR TITLE
Remove logger initialization.

### DIFF
--- a/pypacker/pypacker.py
+++ b/pypacker/pypacker.py
@@ -11,7 +11,6 @@ from struct import Struct
 
 from pypacker.pypacker_meta import MetaPacket
 
-logging.basicConfig(format="%(levelname)s (%(funcName)s): %(message)s")
 logger = logging.getLogger("pypacker")
 logger.setLevel(logging.WARNING)
 # logger.setLevel(logging.INFO)


### PR DESCRIPTION
The user of the library is responsible for logger initialization.
If initialization is made from library than import pypacker
cause that the logger contains a handler which user cannot control.
Eventually, it can leads to uncontrolled logger output.