### PR TITLE
Updated python version in setup.py due to issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(name="pypacker",
 		"Programming Language :: Python :: Implementation :: CPython",
 		"Programming Language :: Python :: Implementation :: PyPy"
 	],
-	python_requires=">=3.3.*,>=3.4.*,>=3.5.*,>=3.6.*"
+	python_requires=">=3.3.*"
 )


### PR DESCRIPTION
Pip install logs:
$pip install -r requirements.txt
...
Obtaining pypacker from
git+https://github.com/mike01/pypacker@master#egg=pypacker (from -r
requirements.txt (line 18))
  Cloning https://github.com/mike01/pypacker (to master) to ./src/pypacker
  pypacker requires Python '>=3.3.*,>=3.4.*,>=3.5.*,>=3.6.*' but the
  running Python is 3.5.2

Signed-off-by: Tkachuk <nazarx.tkachuk@intel.com>