### PR TITLE
Automatic next header deduction

### DIFF
--- a/pypacker/layer12/ethernet.py
+++ b/pypacker/layer12/ethernet.py
@@ -106,7 +106,7 @@ class Ethernet(pypacker.Packet):
 		("src", "6s", b"\xff" * 6),
 		("vlan", None, triggerlist.TriggerList),
 		# ("len", "H", None),
-		("type", "H", ETH_TYPE_IP)		# type = Ethernet II, len = 802.3
+		("type", "H", ETH_TYPE_IP, True)		# type = Ethernet II, len = 802.3
 	)
 
 	dst_s = pypacker.get_property_mac("dst")
@@ -185,6 +185,16 @@ class Ethernet(pypacker.Packet):
 
 	def bin(self, update_auto_fields=True):
 		"""Custom bin(): handle padding for Ethernet."""
+
+		# Check if body was modified and change accordingly ethernet type
+		if update_auto_fields and self._body_changed and self.type_au_active and self.upper_layer is not None:
+			# Build ETH_TYPE_XXX which is same format as is used definition of ethernet types
+			# XXX is get from upper layer class name
+			type_name = "ETH_TYPE_%s" % self.upper_layer.__class__.__name__
+			# Check if ETH_TYPE_XXX is defined
+			if type_name in globals():
+				self.type = globals()[type_name]
+
 		return pypacker.Packet.bin(self, update_auto_fields=update_auto_fields) + self.padding
 
 	def __len__(self):

--- a/pypacker/layer12/ethernet.py
+++ b/pypacker/layer12/ethernet.py
@@ -193,6 +193,7 @@ class Ethernet(pypacker.Packet):
 			type_name = "ETH_TYPE_%s" % self.upper_layer.__class__.__name__
 			# Check if ETH_TYPE_XXX is defined
 			if type_name in globals():
+				# logger.debug("Replace type field with %s" % type_name)
 				self.type = globals()[type_name]
 
 		return pypacker.Packet.bin(self, update_auto_fields=update_auto_fields) + self.padding

--- a/pypacker/layer3/ip.py
+++ b/pypacker/layer3/ip.py
@@ -75,7 +75,7 @@ class IP(pypacker.Packet):
 		# TODO: rename to frag_off
 		("off", "H", 0),
 		("ttl", "B", 64),
-		("p", "B", IP_PROTO_TCP),
+		("p", "B", IP_PROTO_TCP, True),
 		("sum", "H", 0, True),
 		("src", "4s", b"\x00" * 4),
 		("dst", "4s", b"\x00" * 4),
@@ -212,6 +212,12 @@ class IP(pypacker.Packet):
 				# logger.debug("IP: new hl: %d / %d" % (self._packet.hdr_len, hdr_len_off))
 				# logger.debug("new sum: %0X" % self.sum)
 				# logger.debug("new sum: %d" % self.sum)
+			if self.p_au_active and self.upper_layer is not None:
+				# Build protocol name in the format IP_PROTO_XXX which is
+				# same as IP protocol definition in in the ip_shared module.
+				protocol_name = "IP_PROTO_%s" % self.upper_layer.__class__.__name__
+				if protocol_name in globals():
+					self.p = globals()[protocol_name]
 
 		return pypacker.Packet.bin(self, update_auto_fields=update_auto_fields)
 

--- a/pypacker/layer3/ip.py
+++ b/pypacker/layer3/ip.py
@@ -217,6 +217,7 @@ class IP(pypacker.Packet):
 				# same as IP protocol definition in in the ip_shared module.
 				protocol_name = "IP_PROTO_%s" % self.upper_layer.__class__.__name__
 				if protocol_name in globals():
+					# logger.debug("Replace protocol field with %s" % protocol_name)
 					self.p = globals()[protocol_name]
 
 		return pypacker.Packet.bin(self, update_auto_fields=update_auto_fields)

--- a/pypacker/layer3/ip6.py
+++ b/pypacker/layer3/ip6.py
@@ -111,6 +111,7 @@ class IP6(pypacker.Packet):
 				if nxt is None:
 					# Unknown IPv6 Extension header, do nothing
 					return pypacker.Packet.bin(self, update_auto_fields)
+
 				nxts.append(nxt)
 
 				for opt_index in range(len(self.opts) - 1):
@@ -121,16 +122,20 @@ class IP6(pypacker.Packet):
 					nxts.append(nxt)
 
 				# First apply new nxt in IPv6 header
+				# logger.debug("Replace nxt field in IPv6 header with 0x%x" % nxts[0])
 				self.nxt = nxts[0]
 
 				# Than apply new nxt in IPv6 extensions headers
 				for i in range(len(nxts) - 1):
+					# logger.debug("Replace nxt field in %d. IPv6 extension header with 0x%x" % (i, nxts[i + 1]))
 					self.opts[i].nxt = nxts[i + 1]
 
 				def set_last_nxt(value):
+					# logger.debug("Replace nxt field in last IPv6 extension header with 0x%x" % value)
 					self.opts[-1].__setattr__("nxt", value)
 			else:
 				def set_last_nxt(value):
+					# logger.debug("Replace nxt field in IPv6 header with 0x%x" % value)
 					self.nxt.__setattr__("nxt", value)
 
 			if self.upper_layer is not None:


### PR DESCRIPTION
Add automatic upper layer protocol deduction for fields like type in Ethernet. This commits add support of this feature for Ethernet, IPv4 and IPv6 (including IPv6 extension headers).