### PR TITLE
Resolve two bugs: ieee80211 and triggerlist

### DIFF
--- a/pypacker/layer12/ieee80211.py
+++ b/pypacker/layer12/ieee80211.py
@@ -298,8 +298,8 @@ class IEEE80211(pypacker.Packet):
 	class AssocResp(pypacker.Packet):
 		__hdr__ = (
 			("dst", "6s", b"\x00" * 6),
-			("bssid", "6s", b"\x00" * 6),
 			("src", "6s", b"\x00" * 6),
+			("bssid", "6s", b"\x00" * 6),
 			("seq_frag", "H", 0),
 			("capa", "H", 0),
 			("status", "H", 0),
@@ -329,8 +329,8 @@ class IEEE80211(pypacker.Packet):
 	class Disassoc(pypacker.Packet):
 		__hdr__ = (
 			("dst", "6s", b"\x00" * 6),
-			("bssid", "6s", b"\x00" * 6),
 			("src", "6s", b"\x00" * 6),
+			("bssid", "6s", b"\x00" * 6),
 			("seq_frag", "H", 0),
 			("reason", "H", 0),
 		)
@@ -353,8 +353,8 @@ class IEEE80211(pypacker.Packet):
 	class ReassocReq(pypacker.Packet):
 		__hdr__ = (
 			("dst", "6s", b"\x00" * 6),
-			("bssid", "6s", b"\x00" * 6),
 			("src", "6s", b"\x00" * 6),
+			("bssid", "6s", b"\x00" * 6),
 			("seq_frag", "H", 0),
 			("capa", "H", 0),
 			("interval", "H", 0),

--- a/pypacker/triggerlist.py
+++ b/pypacker/triggerlist.py
@@ -100,6 +100,10 @@ class TriggerList(list):
 		self._lazy_dissect()
 		return super().__len__()
 
+        def __iter__(self):
+		self._lazy_dissect()
+		return super().__iter__()
+
 	def append(self, v):
 		self._lazy_dissect()
 		super().append(v)


### PR DESCRIPTION
First bug: WiFi management packets (to_ds=0, from_ds=0) use the following ordering
for MAC addresses: dst, src, bssid. Fix parsing to reflect the correct
order.